### PR TITLE
出庫管理データグリットビューの設定とその他修正

### DIFF
--- a/SalesManagement_SysDev/ChumonKanri.Designer.cs
+++ b/SalesManagement_SysDev/ChumonKanri.Designer.cs
@@ -242,7 +242,7 @@
             this.ChumonjyoutaiFlaguCmb.Location = new System.Drawing.Point(237, 376);
             this.ChumonjyoutaiFlaguCmb.Name = "ChumonjyoutaiFlaguCmb";
             this.ChumonjyoutaiFlaguCmb.Size = new System.Drawing.Size(201, 26);
-            this.ChumonjyoutaiFlaguCmb.TabIndex = 55;
+            this.ChumonjyoutaiFlaguCmb.TabIndex = 8;
             // 
             // ChumonjyoutaiFlaguLbl
             // 
@@ -262,7 +262,7 @@
             this.ChumonDetailDgv.RowHeadersWidth = 62;
             this.ChumonDetailDgv.RowTemplate.Height = 27;
             this.ChumonDetailDgv.Size = new System.Drawing.Size(633, 256);
-            this.ChumonDetailDgv.TabIndex = 54;
+            this.ChumonDetailDgv.TabIndex = 52;
             this.ChumonDetailDgv.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ChumonDetailDgv_CellClick);
             // 
             // EigyoushoNameCmb
@@ -280,7 +280,7 @@
             this.ChumonnengappiDtm.Name = "ChumonnengappiDtm";
             this.ChumonnengappiDtm.ShowCheckBox = true;
             this.ChumonnengappiDtm.Size = new System.Drawing.Size(201, 25);
-            this.ChumonnengappiDtm.TabIndex = 5;
+            this.ChumonnengappiDtm.TabIndex = 4;
             this.ChumonnengappiDtm.Value = new System.DateTime(2023, 11, 24, 0, 0, 0, 0);
             // 
             // GamenKousinBtn
@@ -316,7 +316,7 @@
             this.ChumonKanriFlagCmb.Location = new System.Drawing.Point(653, 376);
             this.ChumonKanriFlagCmb.Name = "ChumonKanriFlagCmb";
             this.ChumonKanriFlagCmb.Size = new System.Drawing.Size(201, 26);
-            this.ChumonKanriFlagCmb.TabIndex = 8;
+            this.ChumonKanriFlagCmb.TabIndex = 9;
             // 
             // HihyojiTxb
             // 
@@ -327,7 +327,7 @@
             this.HihyojiTxb.Multiline = true;
             this.HihyojiTxb.Name = "HihyojiTxb";
             this.HihyojiTxb.Size = new System.Drawing.Size(606, 90);
-            this.HihyojiTxb.TabIndex = 9;
+            this.HihyojiTxb.TabIndex = 10;
             // 
             // ShainIDTxb
             // 
@@ -348,7 +348,7 @@
             this.JuchuIDTxb.Location = new System.Drawing.Point(237, 220);
             this.JuchuIDTxb.Name = "JuchuIDTxb";
             this.JuchuIDTxb.Size = new System.Drawing.Size(201, 25);
-            this.JuchuIDTxb.TabIndex = 4;
+            this.JuchuIDTxb.TabIndex = 3;
             // 
             // ShohinIDTxb
             // 
@@ -369,7 +369,7 @@
             this.KokyakuIDTxb.Location = new System.Drawing.Point(1055, 218);
             this.KokyakuIDTxb.Name = "KokyakuIDTxb";
             this.KokyakuIDTxb.Size = new System.Drawing.Size(201, 25);
-            this.KokyakuIDTxb.TabIndex = 3;
+            this.KokyakuIDTxb.TabIndex = 5;
             this.KokyakuIDTxb.TextChanged += new System.EventHandler(this.KokyakuIDTxb_TextChanged);
             // 
             // SuryoTxb

--- a/SalesManagement_SysDev/ChumonKanri.cs
+++ b/SalesManagement_SysDev/ChumonKanri.cs
@@ -159,6 +159,7 @@ namespace SalesManagement_SysDev
             ChumonKanriFlagCmb.Items.Add("表示");
             ChumonKanriFlagCmb.Items.Add("非表示");
             HihyojiTxb.Text = "";
+            ChumonIDTxb.Enabled = true;
             ConfirmBtn.Enabled = false;
             HiddenBtn.Enabled = false;
 
@@ -351,6 +352,10 @@ namespace SalesManagement_SysDev
 
             Chumon = chDataAccess.GetChData(int.Parse(ChumonDetailDgv.Rows[ChumonDetailDgv.CurrentRow.Index].Cells[1].Value.ToString()));
 
+            ChumonIDTxb.Enabled = false;
+            ConfirmBtn.Enabled = true;
+            HiddenBtn.Enabled = true;
+
             SetchDataGridView();
         }
 
@@ -393,20 +398,20 @@ namespace SalesManagement_SysDev
                 }
             }
 
-            if(KokyakuIDTxb.Text != "")
-            {
-                if (!inputCheck.CheckClID(KokyakuIDTxb.Text).flg)
-                {
-                    messageDsp.DspMsg(inputCheck.CheckClID(KokyakuIDTxb.Text).Msg);
-                    return false;
-                }
-            }
-
-            if(JuchuIDTxb.Text != "")
+            if (JuchuIDTxb.Text != "")
             {
                 if (!inputCheck.CheckRegistOrID(JuchuIDTxb.Text).flg)
                 {
                     messageDsp.DspMsg(inputCheck.CheckRegistOrID(JuchuIDTxb.Text).Msg);
+                    return false;
+                }
+            }
+
+            if (KokyakuIDTxb.Text != "")
+            {
+                if (!inputCheck.CheckClID(KokyakuIDTxb.Text).flg)
+                {
+                    messageDsp.DspMsg(inputCheck.CheckClID(KokyakuIDTxb.Text).Msg);
                     return false;
                 }
             }
@@ -424,11 +429,11 @@ namespace SalesManagement_SysDev
 
         private T_Chumon SetChSearchData()
         {
-            int chid = 0;
+            int chid = -1;
             int soid = 0;
             int emid = 0;
             int clid = 0;
-            int orid = 0;
+            int orid = -1;
             DateTime date = DateTime.ParseExact("00010101", "yyyymmdd", null);
             int chsflg = -1;
             int chflg = -1;
@@ -506,7 +511,7 @@ namespace SalesManagement_SysDev
         private T_ChumonDetail SetChdSearchData()
         {
             //int chdid = 0;
-            int chid = 0;
+            int chid = -1;
             int prid = 0;
 
             if(ChumonIDTxb.Text != "")
@@ -745,6 +750,7 @@ namespace SalesManagement_SysDev
         {
             if(!inputCheck.CheckSuuti(ShohinIDTxb.Text))
             {
+                ShohinName.Text = "--";
                 return;
             }
 
@@ -755,6 +761,7 @@ namespace SalesManagement_SysDev
         {
             if (!inputCheck.CheckSuuti(ShainIDTxb.Text))
             {
+                ShainName.Text = "--";
                 return;
             }
 
@@ -765,6 +772,7 @@ namespace SalesManagement_SysDev
         {
             if (!inputCheck.CheckSuuti(KokyakuIDTxb.Text))
             {
+                KokyakuName.Text = "--";
                 return;
             }
 

--- a/SalesManagement_SysDev/DataAccess/ChumonDataAccess.cs
+++ b/SalesManagement_SysDev/DataAccess/ChumonDataAccess.cs
@@ -184,7 +184,7 @@ namespace SalesManagement_SysDev.DataAccess
             List<T_ChumonDsp> Chumon = new List<T_ChumonDsp>();
             DateTime nulldate = DateTime.ParseExact("00010101", "yyyymmdd", null);
 
-            if (T_Ch.ChID != 0 && T_Ch.ChFlag == -1)
+            if (T_Ch.ChID != -1 && T_Ch.ChFlag == -1)
             {
                 try
                 {
@@ -235,7 +235,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if(T_Ch.ChID != 0 && T_Ch.ChFlag != -1)
+            else if(T_Ch.ChID != -1 && T_Ch.ChFlag != -1)
             {
                 try
                 {
@@ -286,7 +286,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if(T_Ch.OrID != 0 && T_Ch.ChFlag == -1)
+            else if(T_Ch.OrID != -1 && T_Ch.ChFlag == -1)
             {
                 try
                 {
@@ -337,7 +337,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.OrID != 0 && T_Ch.ChFlag != -1)
+            else if (T_Ch.OrID != -1 && T_Ch.ChFlag != -1)
             {
                 try
                 {
@@ -4085,8 +4085,8 @@ namespace SalesManagement_SysDev.DataAccess
                              on t1.ClID equals t4.ClID
                              join t5 in context.T_Orders
                              on t1.OrID equals t5.OrID
-                             join t6 in context.T_ChumonDetails
-                             on t1.ChID equals t6.ChID
+                             //join t6 in context.T_ChumonDetails
+                             //on t1.ChID equals t6.ChID
                              where t1.ChFlag == 0 &&
                                    (t1.ChHidden.Contains(T_Ch.ChHidden) ||
                                    t1.ChHidden == null)

--- a/SalesManagement_SysDev/DataAccess/ChumonDetailDataAccess.cs
+++ b/SalesManagement_SysDev/DataAccess/ChumonDetailDataAccess.cs
@@ -96,7 +96,7 @@ namespace SalesManagement_SysDev.DataAccess
             List<T_ChumonDetailDsp> Chumon = new List<T_ChumonDetailDsp>();
             DateTime nulldate = DateTime.ParseExact("00010101", "yyyymmdd", null);
 
-            if (T_Ch.ChID != 0 && T_Ch.ChFlag == -1 && T_Chd.PrID == 0)
+            if (T_Ch.ChID != -1 && T_Ch.ChFlag == -1 && T_Chd.PrID == 0)
             {
                 try
                 {
@@ -133,7 +133,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.ChID != 0 && T_Ch.ChFlag != -1 && T_Chd.PrID == 0)
+            else if (T_Ch.ChID != -1 && T_Ch.ChFlag != -1 && T_Chd.PrID == 0)
             {
                 try
                 {
@@ -170,7 +170,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.ChID != 0 && T_Ch.ChFlag != -1 && T_Chd.PrID != 0)
+            else if (T_Ch.ChID != -1 && T_Ch.ChFlag != -1 && T_Chd.PrID != 0)
             {
                 try
                 {
@@ -208,7 +208,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.ChID != 0 && T_Ch.ChFlag == -1 && T_Chd.PrID != 0)
+            else if (T_Ch.ChID != -1 && T_Ch.ChFlag == -1 && T_Chd.PrID != 0)
             {
                 try
                 {
@@ -246,7 +246,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.OrID != 0 && T_Ch.ChFlag == -1 && T_Chd.PrID == 0)
+            else if (T_Ch.OrID != -1 && T_Ch.ChFlag == -1 && T_Chd.PrID == 0)
             {
                 try
                 {
@@ -283,7 +283,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.OrID != 0 && T_Ch.ChFlag != -1 && T_Chd.PrID == 0)
+            else if (T_Ch.OrID != -1 && T_Ch.ChFlag != -1 && T_Chd.PrID == 0)
             {
                 try
                 {
@@ -320,7 +320,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.OrID != 0 && T_Ch.ChFlag != -1 && T_Chd.PrID != 0)
+            else if (T_Ch.OrID != -1 && T_Ch.ChFlag != -1 && T_Chd.PrID != 0)
             {
                 try
                 {
@@ -358,7 +358,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.OrID != 0 && T_Ch.ChFlag == -1 && T_Chd.PrID != 0)
+            else if (T_Ch.OrID != -1 && T_Ch.ChFlag == -1 && T_Chd.PrID != 0)
             {
                 try
                 {
@@ -396,7 +396,7 @@ namespace SalesManagement_SysDev.DataAccess
                     MessageBox.Show(ex.Message, "例外エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
-            else if (T_Ch.SoID != 0 && T_Ch.ClID != 0 && T_Ch.ChDate != nulldate &&
+            else if (T_Ch.SoID != -1 && T_Ch.ClID != 0 && T_Ch.ChDate != nulldate &&
                         T_Ch.ChFlag != -1 && T_Ch.ChStateFlag != -1 && T_Chd.PrID != 0)
             {
                 try

--- a/SalesManagement_SysDev/DataAccess/EmployeeDataAccess.cs
+++ b/SalesManagement_SysDev/DataAccess/EmployeeDataAccess.cs
@@ -222,7 +222,7 @@ namespace SalesManagement_SysDev.DataAccess
             DateTime nulldate = DateTime.ParseExact("00010101","yyyymmdd",null);
 
             //社員ID入力
-            if (regEmployee.EmID != 0 && regEmployee.EmFlag == -1)
+            if (regEmployee.EmID != -1 && regEmployee.EmFlag == -1)
             {
                 try
                 {
@@ -270,7 +270,7 @@ namespace SalesManagement_SysDev.DataAccess
                 }
             }
             //社員ID入力、社員管理フラグ選択
-            else if (regEmployee.EmID != 0 && regEmployee.EmFlag != -1)
+            else if (regEmployee.EmID != -1 && regEmployee.EmFlag != -1)
             {
                 try
                 {

--- a/SalesManagement_SysDev/DataAccess/SyukkoDataAccess.cs
+++ b/SalesManagement_SysDev/DataAccess/SyukkoDataAccess.cs
@@ -9,6 +9,8 @@ namespace SalesManagement_SysDev.DataAccess
 {
     internal class SyukkoDataAccess
     {
+        EmployeeDataAccess EmpDA;
+
         public bool RegistSyukkoData(T_Syukko t_Syukko)
         {
             try
@@ -64,18 +66,18 @@ namespace SalesManagement_SysDev.DataAccess
                 var tb = from t1 in context.T_Syukkos
                          join t2 in context.M_SalesOffices
                          on t1.SoID equals t2.SoID
-                         join t3 in context.M_Employees
-                         on t1.EmID equals t3.EmID
+                         //join t3 in context.M_Employees
+                         //on t1.EmID equals t3.EmID
                          join t4 in context.M_Clients
                          on t1.ClID equals t4.ClID
                          join t5 in context.T_Orders
                          on t1.OrID equals t5.OrID
-                         where t1.SyFlag == 0
+                         where t1.SyFlag == 0   
                          select new
                          {
                              t1.SyID,
                              t2.SoName,
-                             t3.EmName,
+                             t1.EmID,
                              t4.ClName,
                              t1.OrID,
                              t1.SyDate,
@@ -86,18 +88,38 @@ namespace SalesManagement_SysDev.DataAccess
 
                 foreach (var p in tb)
                 {
-                    Syukko.Add(new T_SyukkoDsp()
+                    if(p.EmID == null)
                     {
-                        SyID = p.SyID,
-                        EmName = p.EmName,
-                        SoName = p.SoName,
-                        ClName = p.ClName,
-                        OrID = p.OrID,
-                        SyDate = p.SyDate,
-                        SyFlag = p.SyFlag,
-                        SyStateFlag = p.SyStateFlag,
-                        SyHidden = p.SyHidden
-                    });
+                        Syukko.Add(new T_SyukkoDsp()
+                        {
+                            SyID = p.SyID,
+                            EmName = "未確定",
+                            SoName = p.SoName,
+                            ClName = p.ClName,
+                            OrID = p.OrID,
+                            SyDate = p.SyDate,
+                            SyFlag = p.SyFlag,
+                            SyStateFlag = p.SyStateFlag,
+                            SyHidden = p.SyHidden
+                        });
+                    }
+                    else
+                    {
+                        Syukko.Add(new T_SyukkoDsp()
+                        {
+                            SyID = p.SyID,
+                            EmName = EmpDA.GetEmName((int)p.EmID),
+                            SoName = p.SoName,
+                            ClName = p.ClName,
+                            OrID = p.OrID,
+                            SyDate = p.SyDate,
+                            SyFlag = p.SyFlag,
+                            SyStateFlag = p.SyStateFlag,
+                            SyHidden = p.SyHidden
+                        });
+                    }
+
+                    
                 }
                 context.Dispose();
             }

--- a/SalesManagement_SysDev/ShainKanri.cs
+++ b/SalesManagement_SysDev/ShainKanri.cs
@@ -345,20 +345,20 @@ namespace SalesManagement_SysDev
                 return false;
             }
 
-            //電話番号の入力チェック
-            if (!InputCheck.CheckEmPhone(TelTxb.Text).flg)
-            {
-                MessageDsp.DspMsg(InputCheck.CheckEmPhone(TelTxb.Text).Msg);
-                TelTxb.Focus();
-                return false;
-            }
-
             //営業所名の入力チェック
             if (!InputCheck.CheckSoNameCmb(EigyoushoNameCmb.Text).flg)
             {
                 MessageDsp.DspMsg(InputCheck.CheckSoNameCmb(EigyoushoNameCmb.Text).Msg);
                 return false;
             }
+
+            //電話番号の入力チェック
+            if (!InputCheck.CheckEmPhone(TelTxb.Text).flg)
+            {
+                MessageDsp.DspMsg(InputCheck.CheckEmPhone(TelTxb.Text).Msg);
+                TelTxb.Focus();
+                return false;
+            } 
 
             //役職名の入力チェック
             if (!InputCheck.CheckPoNameCmb(YakushokuNameCmb.Text).flg)
@@ -706,7 +706,7 @@ namespace SalesManagement_SysDev
         private M_Employee SetEmployeeSearchData()
         {
             int poid = 0;
-            int emid = 0;
+            int emid = -1;
             int soid = 0;
             int emflg = -1;
             DateTime date = DateTime.ParseExact("00010101", "yyyymmdd", null);


### PR DESCRIPTION
出庫管理のデータグリットビューが正しく表示されるように修正
社員検索で社員IDに0を入力して検索したときに正しく表示されるように修正
注文検索で注文IDに0を入力して検索したときに正しく表示されるように修正
注文管理の社員ID、商品ID、顧客IDを入力した後テキストボックスが空白になったとき社員名、商品名、顧客名が”--”になるように修正